### PR TITLE
add openssl aar for build Snapcast v0.31.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.0-alpha07"
+agp = "8.9.0"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"

--- a/snapcast-deps/build.gradle.kts
+++ b/snapcast-deps/build.gradle.kts
@@ -13,6 +13,7 @@ artifacts.add("default", file("libs/opus-1.1.2.aar"))
 artifacts.add("default", file("libs/soxr-0.1.3.aar"))
 artifacts.add("default", file("libs/tremor-1.0.1.aar"))
 artifacts.add("default", file("libs/vorbis-1.3.7.aar"))
+artifacts.add("default", file("libs/openssl-3.2.0.aar"))
 
 fun getSnapcastGitTag(): String =
     ProcessBuilder("git", "describe", "--tags")
@@ -61,6 +62,10 @@ publishing {
             artifact(file("libs/vorbis-1.3.7.aar")) {
                 extension = "aar"
                 classifier = "vorbis"
+            }
+            artifact(file("libs/openssl-3.2.0.aar")) {
+                extension = "aar"
+                classifier = "openssl"
             }
         }
     }


### PR DESCRIPTION
## Description
This PR updates `lib-snapcast-android` to support Snapcast version `v0.31.0` by integrating OpenSSL and resolving build issues. It ensures compatibility with the upcoming Snapcast release and prepares for a smooth migration.

## Changes
- **Added OpenSSL AAR file:**
  - Integrated the OpenSSL AAR file (generated from `snapcast-deps`) to enable secure communication in `snapdroid`.
  - Configured the build to include OpenSSL libraries (`libcrypto.a` and `libssl.a`) with Prefab modules, aligning with [badaix/snapcast-deps#2](https://github.com/badaix/snapcast-deps/pull/2).
- **Fixed AGP error:**
  - Resolved an Android Gradle Plugin (AGP) error to ensure successful builds with the updated dependencies and Snapcast `v0.31.0`.

## Motivation
These changes enable secure audio streaming in `snapdroid` via OpenSSL and ensure build stability for the migration to Snapcast `v0.31.0`.

## Notes
Waiting for [badaix/snapcast#1373](https://github.com/badaix/snapcast/pull/1373) to be approved so we can confidently migrate to version `v0.31.0`. This PR depends on the OpenSSL integration in [badaix/snapcast-deps#2](https://github.com/badaix/snapcast-deps/pull/2).

---
Thank you for reviewing this PR! Please let me know if any additional details or changes are needed.